### PR TITLE
Fix Winnie pronoun in playpen bio

### DIFF
--- a/src/games/playpen/pets.ts
+++ b/src/games/playpen/pets.ts
@@ -37,7 +37,7 @@ export const PLAYPEN_PETS: readonly PlaypenPetManifest[] = [
 	{
 		id: 'winnie',
 		displayName: 'Winnie',
-		description: 'The cutest mini aussie, shy at first but very loving and soft; his best friend is a cat named Steven.',
+		description: 'The cutest mini aussie, shy at first but very loving and soft; her best friend is a cat named Steven.',
 		spritePath: '/games/playpen/pets/winnie/spritesheet.webp',
 	},
 ];


### PR DESCRIPTION
### Motivation
- Correct Winnie’s playpen bio to use the proper pronoun so the description reflects that she is female.

### Description
- Edit `src/games/playpen/pets.ts` to change Winnie’s description from "his best friend is a cat named Steven." to "her best friend is a cat named Steven.".

### Testing
- Verified the change and repository state with `rg -n "Winnie" /workspace/website -S`, `nl -ba src/games/playpen/pets.ts | sed -n '1,120p'`, and `git -C /workspace/website show --stat --oneline HEAD`; no automated tests were required for this content-only update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9fea6a16483219c4a57483b7a6729)