### PR TITLE
Replace 2049 project card with Sarah's Puzzle link

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -920,10 +920,16 @@ const latestBike = stravaData.recent_bikes?.[0];
 			<section class="projects">
 				<span class="section-label">Side Projects</span>
 				<div class="projects-grid">
+					<a href="http://sarahspuzzle.com/" class="project-card" target="_blank" rel="noopener noreferrer" data-umami-event="link_click" data-umami-event-area="projects" data-umami-event-label="sarahs-puzzle">
+						<div class="project-card-title">Sarah's Puzzle</div>
+						<div class="project-card-desc">Crossword puzzle I made to propose to Sarah.</div>
+					</a>
+					<!--
 					<a href="https://www.roblox.com/games/88880963125700/2049-Puzzle" class="project-card" target="_blank" rel="noopener noreferrer" data-umami-event="link_click" data-umami-event-area="projects" data-umami-event-label="2049-puzzle">
 						<div class="project-card-title">2049 Puzzle</div>
 						<div class="project-card-desc">2048-inspired puzzle game built on the Roblox platform.</div>
 					</a>
+					-->
 					<a href="https://www.hypertextlibrary.com/" class="project-card" target="_blank" rel="noopener noreferrer" data-umami-event="link_click" data-umami-event-area="projects" data-umami-event-label="hypertext-library">
 						<div class="project-card-title">Hypertext Library</div>
 						<div class="project-card-desc">Literature-based web project I built in college after a class on Ulysses.</div>


### PR DESCRIPTION
### Motivation
- Replace the 2049/2048-style project entry on the homepage with a link to the crossword puzzle used to propose to Sarah so the public projects grid points to the proposal puzzle.

### Description
- Updated `src/pages/index.astro` to replace the Roblox `2049 Puzzle` project card with a new external card linking to `http://sarahspuzzle.com/` titled `Sarah's Puzzle`, and preserved the original `2049 Puzzle` markup as commented-out HTML for easy restoration.

### Testing
- Ran `npm run build`, which failed in this environment due to Node version incompatibility (`Node v20.20.2` present while Astro requires `>=22.12.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1af3862c832182795f708014761e)