### PR TITLE
Replace The Great Gatsby with new Goodreads entry in favorites

### DIFF
--- a/scripts/recommendations/favorites.json
+++ b/scripts/recommendations/favorites.json
@@ -57,12 +57,7 @@
       "subtitle": "Jorge Luis Borges",
       "cover": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1621713120l/426504.jpg"
     },
-    {
-      "url": "https://www.goodreads.com/book/show/4671.The_Great_Gatsby",
-      "title": "The Great Gatsby",
-      "subtitle": "F. Scott Fitzgerald",
-      "cover": "https://i.gr-assets.com/images/S/compressed.photo.goodreads.com/books/1738790966l/4671.jpg"
-    }
+    "https://www.goodreads.com/book/show/60811826"
   ],
   "orders": {
     "desktop": {
@@ -115,7 +110,7 @@
         "https://www.goodreads.com/book/show/426504.Ficciones",
         "https://www.goodreads.com/book/show/28921.The_Remains_of_the_Day",
         "https://www.goodreads.com/book/show/20613582-10-04",
-        "https://www.goodreads.com/book/show/4671.The_Great_Gatsby"
+        "https://www.goodreads.com/book/show/60811826"
       ]
     }
   }


### PR DESCRIPTION
### Motivation
- Replace the existing Goodreads entry for `The Great Gatsby` on the favorites page with the provided Goodreads URL so the favorites list shows the intended book.

### Description
- Updated `scripts/recommendations/favorites.json` to replace the `The Great Gatsby` entry with the URL `https://www.goodreads.com/book/show/60811826` and updated the mobile `orders.books` list to reference the same URL, then committed the change.

### Testing
- Ran `npm run build` which failed in this environment because Astro requires Node `>=22.12.0` while the current runtime is Node `v20.20.2`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd4742180832194787d9f27afd403)